### PR TITLE
New repo for CRUD

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "php" : ">=5.4",
     "composer/installers" : "~1.0",
     "cakephp/cakephp" : "2.4.0",
-    "jippi/cakephp-crud" : "3.*"
+    "friendsofcake/crud" : "3.*"
   },
   "require-dev": {
     "cakephp/debug_kit" : "2.2.*"


### PR DESCRIPTION
It seems the jippi/cakephp-crud repo is gone or moved to friendsofcake/crud. Composer does not get this, so composer.json must be updated to get it installed.
