### PR TITLE
Removed sql_dump

### DIFF
--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -57,6 +57,5 @@ $cakeDescription = __d('cake_dev', 'CakePHP: the rapid development php framework
 			?>
 		</div>
 	</div>
-	<?php echo $this->element('sql_dump'); ?>
 </body>
 </html>


### PR DESCRIPTION
Remove the default sql_dump element, as per the DebugKit docs.

> Make sure to remove the 'sql_dump' element from your layout (usually app/View/Layouts/default.ctp if you want to experience the awesome that is the debug kit SQL log.

https://github.com/cakephp/debug_kit#installation
