### PR TITLE
Make AppModel default use Containable and set recursive to -1

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -32,4 +32,19 @@ App::uses('Model', 'Model');
  * @package       app.Model
  */
 class AppModel extends Model {
+	
+/**
+ * recursive 
+ *
+ * @var int
+ */
+	public $recursive = -1;
+	
+/**
+ * behaviors used by model
+ *
+ * @var array
+ */
+	public $actsAs = ['Containable'];
+	
 }


### PR DESCRIPTION
It's so common to use Containable in my own CakePHP apps that I suggest we set it as default in the app-template as well. Ditto for $this->recursive = -1;
