### PR TITLE
Set default timezone to UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,22 @@
 
 An empty CakePHP project for use with composer
 
-##Installation
+## Installation
 
 	composer -sdev create-project friendsofcake/app-template ProjectName
 
 This will create a new project, with dependencies, based on this repository. Be sure to point
 the webserver at the `app/webroot` folder (a [production install][1]), ensure that [url rewriting][2]
 is configured correctly.
+
+## Non-default Configuration
+
+By default, the following has been enabled:
+
+- Composer Autoloading
+- Setting Timezone to UTC
+
+You may change either of these at your leisure.
 
 ## Note about dependencies
 

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -239,7 +239,7 @@
  * Uncomment this line and correct your server timezone to fix
  * any date & time related errors.
  */
-	//date_default_timezone_set('UTC');
+	date_default_timezone_set('UTC');
 
 /**
  *


### PR DESCRIPTION
I think we can all agree that setting the default to UTC is preferred. It also gets rid of errors for those who don't have a default set - if you install PHP from most places, you won't.
