### PR TITLE
Heroku support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ By default, the following has been enabled:
 
 You may change either of these at your leisure.
 
+## Application Configuration
+
+This template supports - but does not require - configuration of the application via [environment variables](http://en.wikipedia.org/wiki/Environment_variable). This is not required for application configuration - and can be ignored - but is useful on Cloud Platforms and for those requiring extra security around sharing of application secrets and tokens.
+
+To reduce complexity around using the use of this methodology locally, we have also included the [josegonzalez/php-dotenv](https://github.com/josegonzalez/php-dotenv) library to load environment variables within your `app/Config/core.php`. You can create a `app/Config/.env` file with your configuration and have it autoloaded by the `php-dotenv` project. A sample `app/Config/.env.default` has been included for your convenience.
+
+## Heroku Compatibility
+
+This application template is compatible with the [CHH/heroku-buildpack-php](https://github.com/CHH/heroku-buildpack-php) project. To use, simply configure your buildpack:
+
+    heroku config:set BUILDPACK_URL=https://github.com/CHH/heroku-buildpack-php
+    heroku config:set LOG_PATH=/app/vendor/php/var/log/
+    heroku config:set SECURITY_SALT=SOME_ALPHANUMERIC_SALT_HERE
+    heroku config:set SECURITY_CIPHER_SEED=SOME_NUMERIC_SEED_HERE
+
 ## Note about dependencies
 
 FriendsOfCake encourages the use of composer and it's best not to mix composer with git submodules for

--- a/app/Config/.env.default
+++ b/app/Config/.env.default
@@ -1,0 +1,8 @@
+export APP_NAME=app
+export CACHE_PREFIX="myapp_"
+export CACHE_URL="file:"
+export DATABASE_URL="mysql://user:password@localhost:3306/database_name"
+export DEBUG=2
+export SECURITY_SALT="DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi"
+export SECURITY_CIPHER_SEED="76859309657453542496749683645"
+export TEST_DATABASE_URL="mysql://user:password@localhost:3306/test_database_name"

--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -32,16 +32,19 @@ App::build(
 	App::RESET
 );
 
-// Include the Composer autoloader
-App::import('Vendor', array('file' => 'autoload'));
-
-// Remove and re-prepend CakePHP's autoloader as composer thinks it is the most important.
-// See https://github.com/composer/composer/commit/c80cb76b9b5082ecc3e5b53b1050f76bb27b127b
-spl_autoload_unregister(array('App', 'load'));
-spl_autoload_register(array('App', 'load'), true, true);
-
 // Setup a 'default' cache configuration for use in the application.
-Cache::config('default', ['engine' => 'File']);
+$_CACHE_URL = parseUrlFromEnv('CACHE_URL', 'file:');
+Cache::config('default', array(
+	'engine' => ucfirst(Hash::get($_CACHE_URL, 'scheme')),
+	'prefix' => 'app_default_',
+	'serialize' => ($engine === 'File'),
+	'duration' => '+999 days',
+	'login' => Hash::get($_CACHE_URL, 'user'),
+	'password' => Hash::get($_CACHE_URL, 'pass'),
+	'server' => Hash::get($_CACHE_URL, 'host'),
+	'servers' => Hash::get($_CACHE_URL, 'host'),
+	'port' => Hash::get($_CACHE_URL, 'port'),
+));
 
 /**
  * The settings below can be used to set additional paths to models, views and controllers.
@@ -134,10 +137,12 @@ App::uses('CakeLog', 'Log');
 CakeLog::config('debug', [
 	'engine' => 'FileLog',
 	'types' => ['notice', 'info', 'debug'],
+	'path' =>  env('LOG_PATH') :? LOGS,
 	'file' => 'debug',
 ]);
 CakeLog::config('error', [
 	'engine' => 'FileLog',
 	'types' => ['warning', 'error', 'critical', 'alert', 'emergency'],
+	'path' =>  env('LOG_PATH') :? LOGS,
 	'file' => 'error',
 ]);

--- a/app/Config/database.php.default
+++ b/app/Config/database.php.default
@@ -76,4 +76,27 @@ class DATABASE_CONFIG {
 		'prefix' => '',
 		'encoding' => 'utf8',
 	);
+
+	public function __construct() {
+		$parsed_urls = array(
+			'default' => parseUrlFromEnv('DATABASE_URL'),
+			'test' => parseUrlFromEnv('TEST_DATABASE_URL'),
+		);
+
+		foreach ($parsed_urls as $connection => $parsed) {
+			if ($parsed) {
+				$this->$connection = array(
+					'datasource' => 'Database/' . ucfirst(strtolower($parsed['scheme'])),
+					'persistent' => false,
+					'host'       => Hash::get($parsed, 'host'),
+					'login'      => Hash::get($parsed, 'user'),
+					'password'   => Hash::get($parsed, 'pass'),
+					'database'   => substr($parsed['path'], 1),
+					'prefix'     => '',
+					'encoding'   => 'utf8',
+				);
+			}
+		}
+	}
+
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "php" : ">=5.4",
     "composer/installers" : "~1.0",
     "pear-pear.cakephp.org/CakePHP" : "2.4.*",
-    "friendsofcake/crud" : "3.*"
+    "friendsofcake/crud" : "3.*",
+    "josegonzalez/dotenv": "0.1.*"
   },
   "require-dev": {
     "cakephp/debug_kit" : "2.2.*"
@@ -23,5 +24,11 @@
   ],
   "config": {
     "preferred-install": "source"
+  },
+  "extra": {
+    "heroku": {
+      "document-root": "app/webroot",
+      "index-document": "index.php"
+    }
   }
 }


### PR DESCRIPTION
<del>Waiting on merge of (forthcoming) CakePHP support in the CHH/heroku-buildpack-php#73 buildpack.</dev>
### Summary
- Allows users to configure their database using a `DATABASE_URL` environment variable
- Adds support for configuring the cache using <del>`MEMCACHED_URL`</del> and `REDIS_URL`. Memcache requires a Memcached engine (not in 2.4.x) with SASL support.
- Adds the ability to set the `LOG_PATH` env var, which is useful for heroku to centralize logs. Defaults to old `LOGS` value.
- Sets the db connection encoding to `utf8`.
- Adds some helper methods for dealing with environment variables
- Adds some information on configuring your application for heroku support
### Test application

[This app](http://cakephp-test.herokuapp.com/) has the buildpack in use (no customizations other than whats in this PR, plus a few env vars): http://cakephp-test.herokuapp.com/

Seems strong so far.
### Todo
- [x] Test pretty urls
- [x] Unify with the nginx config we have in the book
- [x] Ensure <del>Memcached</del> and Redis support work as desired.
