### PR TITLE
If the crud component isn't loaded - bail early

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -88,6 +88,11 @@ if (php_sapi_name() !== 'cli' && Configure::read('debug') && in_array('DebugKit'
 	App::uses('CakeEventManager', 'Event');
 	CakeEventManager::instance()->attach(function($event) {
 		$controller = $event->subject();
+
+		if (!isset($controller->Crud)) {
+			return;
+		}
+
 		$controller->Toolbar = $controller->Components->load(
 			'DebugKit.Toolbar',
 			[


### PR DESCRIPTION
Don't try and load a panel that doesn't exist, don't try and reference a
component that doesn't exist
