### PR TITLE
prevent dir listings

### DIFF
--- a/webroot/.htaccess
+++ b/webroot/.htaccess
@@ -1,3 +1,6 @@
+# It is recommended to integrate https://github.com/h5bp/server-configs also.
+# If you're using apache, preferably directly into your apache config files disabling .htaccess files =)
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
This rule permits urls like:

```
/css/
/js/
/img/
```

to show a file listing (depending on apache setup of course). By default
this most likely is not what users want
