### PR TITLE
Replace "404 Not Found" with a nicer message.

### DIFF
--- a/app/View/Pages/home.ctp
+++ b/app/View/Pages/home.ctp
@@ -17,8 +17,9 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-if (!Configure::read('debug')):
-	throw new NotFoundException();
+if (!Configure::read('debug')): ?><h2>Rapid Application Development</h2><?php
+	CakeLog::write('warning', 'Replace your app/View/Pages/home.ctp');
+	return;
 endif;
 App::uses('Debugger', 'Utility');
 ?>
@@ -113,7 +114,7 @@ if (isset($filePresent)):
 	<?php
 		if ($connected && $connected->isConnected()):
 			echo '<span class="notice success">';
-	 			echo __d('cake_dev', 'Cake is able to connect to the database.');
+				echo __d('cake_dev', 'Cake is able to connect to the database.');
 			echo '</span>';
 		else:
 			echo '<span class="notice">';


### PR DESCRIPTION
CakePHP renders a 404 by default when debug is off, which isn't newb friendly. Instead, we should a simple message and log a warning to users.
