### PR TITLE
Make the pages controller throw 404s

### DIFF
--- a/app/Controller/PagesController.php
+++ b/app/Controller/PagesController.php
@@ -70,6 +70,15 @@ class PagesController extends AppController {
 			$title_for_layout = Inflector::humanize($path[$count - 1]);
 		}
 		$this->set(compact('page', 'subpage', 'title_for_layout'));
-		$this->render(implode('/', $path));
+
+		try {
+			$this->render(implode('/', $path));
+		} catch(MissingViewException $e) {
+			if (!Configure::read('debug')) {
+				throw new NotFoundException();
+			}
+
+			throw $e;
+		}
 	}
 }


### PR DESCRIPTION
In production mode requesting a page that doesn't exist returns a 500.
Instead return a 404, exactly the same response as requesting a
controller/action that doesn't exist.

Only in production mode
