### PR TITLE
Load CakePHP from packagist instead of PEAR

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -288,5 +288,6 @@ if (!env('APP_NAME')) {
 /**
  * Configure logs from environment variables
  */
+	App::uses('CakeLog', 'Log');
 	CakeLog::config('default', LogDsn::parse(env('LOG_URL')));
 	CakeLog::config('error', LogDsn::parse(env('LOG_ERROR_URL')));

--- a/app/Console/cake.php
+++ b/app/Console/cake.php
@@ -22,11 +22,11 @@ $ds = DIRECTORY_SEPARATOR;
 $dispatcher = 'Cake' . $ds . 'Console' . $ds . 'ShellDispatcher.php';
 
 if (function_exists('ini_set')) {
-	$root = dirname(dirname(dirname(__FILE__))) . $ds . 'vendor' . $ds . 'pear-pear.cakephp.org';
+	$root = dirname(dirname(dirname(__FILE__))) . $ds . 'vendor' . $ds . 'cakephp';
 
 	// the following line differs from its sibling
 	// /lib/Cake/Console/Templates/skel/Console/cake.php
-	ini_set('include_path', $root . $ds . 'CakePHP' . PATH_SEPARATOR . ini_get('include_path'));
+	ini_set('include_path', $root . $ds . 'cakephp' . $ds . 'lib' . PATH_SEPARATOR . ini_get('include_path'));
 }
 
 if (!include $dispatcher) {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "php" : ">=5.4",
     "composer/installers" : "~1.0",
-    "pear-pear.cakephp.org/CakePHP" : "2.4.*",
+    "cakephp/cakephp" : "2.4.*",
     "friendsofcake/crud" : "3.*",
     "josegonzalez/dotenv": "0.1.*",
     "ad7six/dsn": "0.1.*"
@@ -17,12 +17,6 @@
     "cakephp/debug_kit" : "2.2.*"
   },
   "minimum-stability": "dev",
-  "repositories" : [
-    {
-      "type" : "pear",
-      "url": "http://pear.cakephp.org/"
-    }
-  ],
   "config": {
     "preferred-install": "source"
   },

--- a/webroot/index.php
+++ b/webroot/index.php
@@ -68,7 +68,7 @@ define('TMP', ROOT . DS . 'tmp' . DS);
  * The following line differs from its sibling
  * /lib/Cake/Console/Templates/skel/webroot/index.php
  */
-define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'vendor' . DS . 'pear-pear.cakephp.org' . DS . 'CakePHP');
+define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib');
 
 /**
  * Editing below this line should NOT be necessary.

--- a/webroot/test.php
+++ b/webroot/test.php
@@ -67,7 +67,7 @@ define('TMP', ROOT . DS . 'tmp' . DS);
  * /lib/Cake/Console/Templates/skel/webroot/test.php
  */
 //define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'lib');
-define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'vendor' . DS . 'pear-pear.cakephp.org' . DS . 'CakePHP');
+define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib');
 
 /**
  * Editing below this line should not be necessary.


### PR DESCRIPTION
Let's try this again.

Refs #31.
Refs 4aa4295f03dfedce4d02388453af5c71d13a9b57.

Seems to be working pretty well, although I have only a small app to test with. The only problem I had was a missing CakeLog error. So I added the `App::uses()` in core.php.

It makes sense though. CakeLog used to be loaded in bootstrap.php and that's where the original repo also has the CakeLog config. That was moved to core.php without the `App::uses()` call. I think previously composer accidentally loaded it somehow, but I'm not sure.

@ADmad, what errors did you get and do you still see those errors with these changes?
