### PR TITLE
Require phpunit 3.7.33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_script:
   - composer install
   - mysql -e 'CREATE DATABASE test_database_name;'
   - export DATABASE_TEST_URL="mysql://travis@localhost/test_database_name?encoding=utf8"
+  - composer global require 'phpunit/phpunit=3.7.33'
+  - ln -s ~/.composer/vendor/phpunit/phpunit/PHPUnit ./vendor/PHPUnit
 
 script:
   -  ./app/Console/cake test app AllAppTests --stderr


### PR DESCRIPTION
TravisCI updated their version to 4.x, breaking all tests for CakePHP apps and plugins that did not manually install PHPUnit.
