### PR TITLE
Comply with CakePHP Codinging Standards

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -81,7 +81,7 @@ CakePlugin::load('Crud');
 if (php_sapi_name() !== 'cli' && Configure::read('debug') && in_array('DebugKit', App::objects('plugin'))) {
 	CakePlugin::load('DebugKit');
 	App::uses('CakeEventManager', 'Event');
-	CakeEventManager::instance()->attach(function($event) {
+	CakeEventManager::instance()->attach(function ($event) {
 		$controller = $event->subject();
 
 		if (!isset($controller->Crud)) {

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -288,6 +288,6 @@ if (!env('APP_NAME')) {
 /**
  * Configure logs from environment variables
  */
- 	App::uses('CakeLog', 'Log');
+	App::uses('CakeLog', 'Log');
 	CakeLog::config('default', LogDsn::parse(env('LOG_URL')));
 	CakeLog::config('error', LogDsn::parse(env('LOG_ERROR_URL')));

--- a/app/Controller/PagesController.php
+++ b/app/Controller/PagesController.php
@@ -48,8 +48,8 @@ class PagesController extends AppController {
 /**
  * Displays a view
  *
- * @param mixed What page to display
  * @return void
+ * @throws NotFoundException
  */
 	public function display() {
 		$path = func_get_args();

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -32,19 +32,19 @@ App::uses('Model', 'Model');
  * @package       app.Model
  */
 class AppModel extends Model {
-	
+
 /**
- * recursive 
+ * recursive
  *
  * @var int
  */
 	public $recursive = -1;
-	
+
 /**
  * behaviors used by model
  *
  * @var array
  */
 	public $actsAs = ['Containable'];
-	
+
 }


### PR DESCRIPTION
There are some minor deviations from the CakePHP Coding Standards that I end up fixing each time I clone the project, to get the [CakePHP Code Sniffer](https://github.com/cakephp/cakephp-codesniffer) to pass successfully. I figured they should probably just be made to the master.

One note though; the three standard php files under app/Config/Schema also cause the sniffer to throw warnings due to missing documentation blocks but this isn't special to the app-template repo, its how CakePHP ships so I wasn't certain how to handle these three files (I usually delete them shortly after cloning). 

If it is desired to have a 100% pass right after cloning, I'm more than happy to add some documentation to the files and submit a new pull request. 
