### PR TITLE
Support Nginx on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: vendor/bin/heroku-php-apache2 webroot/
+web: vendor/bin/heroku-php-nginx -C nginx_app.conf webroot

--- a/nginx_app.conf
+++ b/nginx_app.conf
@@ -1,0 +1,14 @@
+location / {
+    # try to serve file directly, fallback to rewrite
+    try_files $uri @rewriteapp;
+}
+
+location @rewriteapp {
+    # rewrite all to index.php
+    rewrite ^(.*)$ /index.php?$uri&$args last;
+}
+
+location ~ \.php$ {
+    try_files @heroku-fcgi @heroku-fcgi;
+    internal;
+}


### PR DESCRIPTION
Addresses the Nginx problem mentioned in https://github.com/FriendsOfCake/app-template/issues/50
I looked at the old configs in https://github.com/CHH/heroku-buildpack-php/blob/master/conf/nginx/cakephp2.conf.erb and read through the official Heroku support for nginx on Cedar-14, https://devcenter.heroku.com/articles/custom-php-settings#using-a-custom-application-level-nginx-configuration. I salted the dish with som trial and error and came up with this. 
Tested with static assets and pretty urls. Haven't tested with traditional or named params.